### PR TITLE
increase timeout for tests

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -15,7 +15,7 @@ describe("Highscores", () => {
           res.body.should.be.a('object')
           done()
         })
-    })
+    }).timeout(10000)
 
     it("should fail when no username is provided", (done) => {
       chai.request(app)
@@ -34,7 +34,7 @@ describe("Highscores", () => {
           res.body.should.equal("An error occurred")
           done()
         })
-    })
+    }).timeout(10000)
 
 
 


### PR DESCRIPTION
The API calls have been drastically slowed down (I'm not sure why, it's probably cost savings on their part because it's a free offering)

Before the tests would run in ~1 second which is under the default 2 second timeout limit. Now they take ~4 seconds, so I've increased the timeout to 10 seconds to be on the safe side.